### PR TITLE
Upgraded #reset method

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ combobo
 * `goTo`: accepts 1 argument which is either a *String* ('prev' or 'next'), which as it sounds will navigate Combobo to the previous or next option, or the index (*Number*) of the option to be traversed to.  NOTE: This method does not select the option but rather highlights it as if the option is hovered or arrowed to.
 * `select`: selects the currently highlighted option
 * `getOptIndex`: returns the index (within the currently visible options) of the currently selected option.
+* `reset`: clears the filters and deselects any currently selected options.
 
 ### Example usage
 

--- a/dist/combobo.js
+++ b/dist/combobo.js
@@ -138,6 +138,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
             this.input.addEventListener('focus', function () {
               if (_this2.selected.length) {
+                // TODO: Do we really want to clear value in this situation?
                 _this2.input.value = _this2.selected.length >= 2 ? '' : _this2.config.selectionValue(_this2.selected);
               }
             });
@@ -277,7 +278,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
               // Handles if there is a fresh selection
               if (_this4.freshSelection) {
-                _this4.reset();
+                _this4.clearFilters();
                 if (cachedVal && cachedVal.trim() !== _this4.input.value.trim()) {
                   // if the value has changed...
                   _this4.filter().openList();
@@ -292,15 +293,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             });
           }
         }, {
-          key: "reset",
-          value: function reset() {
+          key: "clearFilters",
+          value: function clearFilters() {
             this.cachedOpts.forEach(function (o) {
               return o.style.display = '';
             });
             this.groups.forEach(function (g) {
               return g.element.style.display = '';
             });
-            // reset the opts
+            // show all opts
             this.currentOpts = this.cachedOpts;
             return this;
           }
@@ -407,7 +408,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
             this.input.value = this.selected.length ? this.config.selectionValue(this.selected) : '';
             this.cachedInputValue = this.input.value;
-            this.filter(true).reset().closeList();
+            this.filter(true).clearFilters().closeList();
             this.input.select(); // highlight the input's value
 
             if (newSelected) {
@@ -418,9 +419,26 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             return this;
           }
         }, {
+          key: "reset",
+          value: function reset() {
+            var _this8 = this;
+
+            this.clearFilters();
+            this.input.value = '';
+            this.input.removeAttribute('aria-activedescendant');
+            this.input.removeAttribute('data-active-option');
+            this.currentOption = null;
+            this.selected = [];
+            this.cachedOpts.forEach(function (optEl) {
+              Classlist(optEl).remove(_this8.config.selectedClass);
+              optEl.setAttribute('aria-selected', 'false');
+            });
+            return this;
+          }
+        }, {
           key: "goTo",
           value: function goTo(option, fromKey) {
-            var _this8 = this;
+            var _this9 = this;
 
             if (typeof option === 'string') {
               // 'prev' or 'next'
@@ -449,7 +467,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             this.pseudoFocus(groupChange);
             // Dectecting if element is inView and scroll to it.
             this.currentOpts.forEach(function (opt) {
-              if (opt.classList.contains(_this8.config.activeClass) && !inView(_this8.list, opt)) {
+              if (opt.classList.contains(_this9.config.activeClass) && !inView(_this9.list, opt)) {
                 scrollToElement(opt);
               }
             });
@@ -1368,7 +1386,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
       }
 
       function toByteArray(b64) {
-        var i, j, l, tmp, placeHolders, arr;
+        var i, l, tmp, placeHolders, arr;
         var len = b64.length;
         placeHolders = placeHoldersCount(b64);
 
@@ -1379,7 +1397,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
         var L = 0;
 
-        for (i = 0, j = 0; i < l; i += 4, j += 3) {
+        for (i = 0; i < l; i += 4) {
           tmp = revLookup[b64.charCodeAt(i)] << 18 | revLookup[b64.charCodeAt(i + 1)] << 12 | revLookup[b64.charCodeAt(i + 2)] << 6 | revLookup[b64.charCodeAt(i + 3)];
           arr[L++] = tmp >> 16 & 0xFF;
           arr[L++] = tmp >> 8 & 0xFF;

--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ module.exports = class Combobo {
 
       // Handles if there is a fresh selection
       if (this.freshSelection) {
-        this.reset();
+        this.clearFilters();
         if (cachedVal && (cachedVal.trim() !== this.input.value.trim())) { // if the value has changed...
           this.filter().openList();
           this.freshSelection = false;
@@ -229,10 +229,10 @@ module.exports = class Combobo {
     });
   }
 
-  reset() {
+  clearFilters() {
     this.cachedOpts.forEach((o) => o.style.display = '');
     this.groups.forEach((g) => g.element.style.display = '');
-    // reset the opts
+    // show all opts
     this.currentOpts = this.cachedOpts;
     return this;
   }
@@ -328,7 +328,7 @@ module.exports = class Combobo {
 
     this.input.value = this.selected.length ? this.config.selectionValue(this.selected) : '';
     this.cachedInputValue = this.input.value;
-    this.filter(true).reset().closeList();
+    this.filter(true).clearFilters().closeList();
     this.input.select(); // highlight the input's value
 
     if (newSelected) {
@@ -336,6 +336,20 @@ module.exports = class Combobo {
       this.emit('selection', { text: this.input.value, option: currentOpt });
     }
 
+    return this;
+  }
+
+  reset() {
+    this.clearFilters();
+    this.input.value = '';
+    this.input.removeAttribute('aria-activedescendant');
+    this.input.removeAttribute('data-active-option');
+    this.currentOption = null;
+    this.selected = [];
+    this.cachedOpts.forEach((optEl) => {
+      Classlist(optEl).remove(this.config.selectedClass);
+      optEl.setAttribute('aria-selected', 'false');
+    });
     return this;
   }
 

--- a/test/combobo/index.js
+++ b/test/combobo/index.js
@@ -433,17 +433,67 @@ describe('Combobo', () => {
     });
   });
 
-  describe('reset', () => {
+  describe('clearFilters', () => {
     it('should unhide all options/groups', () => {
       simpleBox.cachedOpts.forEach((o) => o.style.display = 'none');
-      simpleBox.reset();
+      simpleBox.clearFilters();
       assert.equal(0, simpleBox.cachedOpts.filter((o) => o.style.display === 'none').length);
     });
 
     it('should update currentOpts', () => {
       simpleBox.currentOpts = [simpleBox.cachedOpts[0]];
-      simpleBox.reset();
+      simpleBox.clearFilters();
       assert.equal(simpleBox.currentOpts.length, simpleBox.cachedOpts.length);
+    });
+  });
+
+  describe('reset', () => {
+    beforeEach(() => {
+      simpleBox.goTo(1).select();
+    });
+
+    it('should clear the value of the input', () => {
+      assert.equal(simpleBox.input.value, simpleBox.cachedOpts[1].innerText);
+      simpleBox.reset();
+      assert.equal(simpleBox.input.value, '');
+    });
+
+    it('should remove aria-activedescendant from the input', () => {
+      assert.isTrue(!!simpleBox.input.getAttribute('aria-activedescendant'));
+      simpleBox.reset();
+      assert.isFalse(!!simpleBox.input.getAttribute('aria-activedescendant'));
+    });
+
+    it('should remove data-active-option from the input', () => {
+      assert.isTrue(!!simpleBox.input.getAttribute('data-active-option'));
+      simpleBox.reset();
+      assert.isFalse(!!simpleBox.input.getAttribute('data-active-option'));
+    });
+
+    it('should set currentOption to null', () => {
+      assert.isTrue(!!simpleBox.currentOption);
+      simpleBox.reset();
+      assert.isFalse(!!simpleBox.currentOption);
+    });
+
+    it('should set selected to an empty array', () => {
+      assert.equal(simpleBox.selected.length, 1);
+      simpleBox.reset();
+      assert.equal(simpleBox.selected.length, 0);
+    });
+
+    it('should remove the selectedClass from all options', () => {
+      const isSelected = el => Classlist(el).contains(simpleBox.config.selectedClass);
+      assert.equal(simpleBox.cachedOpts.filter(isSelected).length, 1);
+      simpleBox.reset();
+      assert.equal(simpleBox.cachedOpts.filter(isSelected).length, 0);
+    });
+
+    it('should set aria-selected to false on all options', () => {
+      const isSelected = el => el.getAttribute('aria-selected') === 'true';
+      assert.equal(simpleBox.cachedOpts.filter(isSelected).length, 1);
+      simpleBox.reset();
+      assert.equal(simpleBox.cachedOpts.filter(isSelected).length, 0);
     });
   });
 


### PR DESCRIPTION
- Renames `#reset` to `#clearFilters`
- Adds new `#reset` method that clear all filters and also deselects any currently selected options