### PR TITLE
Updates #reset() to also remove the activeClass from the active option

### DIFF
--- a/dist/combobo.js
+++ b/dist/combobo.js
@@ -432,6 +432,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             this.selected = [];
             this.cachedOpts.forEach(function (optEl) {
               Classlist(optEl).remove(_this8.config.selectedClass);
+              Classlist(optEl).remove(_this8.config.activeClass);
               optEl.setAttribute('aria-selected', 'false');
             });
             return this;

--- a/index.js
+++ b/index.js
@@ -349,6 +349,7 @@ module.exports = class Combobo {
     this.selected = [];
     this.cachedOpts.forEach((optEl) => {
       Classlist(optEl).remove(this.config.selectedClass);
+      Classlist(optEl).remove(this.config.activeClass);
       optEl.setAttribute('aria-selected', 'false');
     });
     return this;

--- a/test/combobo/index.js
+++ b/test/combobo/index.js
@@ -489,6 +489,15 @@ describe('Combobo', () => {
       assert.equal(simpleBox.cachedOpts.filter(isSelected).length, 0);
     });
 
+    it('should remove the activeClass from all options', () => {
+      const isActive = el => Classlist(el).contains(simpleBox.config.activeClass);
+      simpleBox.openList();
+      fire(simpleBox.input, 'keydown', { which: 40 });
+      assert.equal(simpleBox.cachedOpts.filter(isActive).length, 1);
+      simpleBox.reset();
+      assert.equal(simpleBox.cachedOpts.filter(isActive).length, 0);
+    });
+
     it('should set aria-selected to false on all options', () => {
       const isSelected = el => el.getAttribute('aria-selected') === 'true';
       assert.equal(simpleBox.cachedOpts.filter(isSelected).length, 1);


### PR DESCRIPTION
I missed this the first time around.