### PR TITLE
Updates #reset() to remove active match styles from all options

### DIFF
--- a/dist/combobo.js
+++ b/dist/combobo.js
@@ -426,6 +426,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
             this.clearFilters();
             this.input.value = '';
+            this.updateOpts();
             this.input.removeAttribute('aria-activedescendant');
             this.input.removeAttribute('data-active-option');
             this.currentOption = null;

--- a/index.js
+++ b/index.js
@@ -343,6 +343,7 @@ module.exports = class Combobo {
   reset() {
     this.clearFilters();
     this.input.value = '';
+    this.updateOpts();
     this.input.removeAttribute('aria-activedescendant');
     this.input.removeAttribute('data-active-option');
     this.currentOption = null;

--- a/test/combobo/index.js
+++ b/test/combobo/index.js
@@ -470,6 +470,16 @@ describe('Combobo', () => {
       assert.isFalse(!!simpleBox.input.getAttribute('data-active-option'));
     });
 
+    it('should remove active style from all options', () => {
+      const activeOpts = () => document.querySelectorAll('.' + simpleBox.config.activeClass, simpleBox.list);
+      simpleBox.openList();
+      fire(simpleBox.input, 'keydown', { which: 40 });
+      fire(simpleBox.input, 'keydown', { which: 13 });
+      assert.isTrue(activeOpts().length > 0);
+      simpleBox.reset();
+      assert.isFalse(activeOpts().length > 0);
+    });
+
     it('should set currentOption to null', () => {
       assert.isTrue(!!simpleBox.currentOption);
       simpleBox.reset();


### PR DESCRIPTION
This ensures that `#reset()` also removes all underlines, boxes, etc. from portions of option text that matched the contents of the input field.