### PR TITLE
Fix invalid attribute for role="combobox"

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -10,7 +10,7 @@ module.exports = (input, list, options) => {
 
   input.setAttribute('role', 'combobox');
   list.setAttribute('role', 'listbox');
-  input.setAttribute('aria-owns', list.id);
+  input.setAttribute('aria-controls', list.id);
   input.setAttribute('aria-autocomplete', 'list');
   input.setAttribute('aria-expanded', 'false');
 


### PR DESCRIPTION
> When the combobox is expanded, authors **MUST** set aria-controls on the textbox element to a value that refers to the combobox popup element.

Required States and Properties:

- aria-controls 

Inherited States and Properties:

- aria-owns



[https://www.w3.org/TR/wai-aria-1.1/#combobox](https://www.w3.org/TR/wai-aria-1.1/#combobox)