### PR TITLE
feat: Dynamically update dropdown options added, disabling front-end dropdown filters if not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ const combobo = new Combobo();
     ```
 * `filter` (_String|Function_): A filter-type string (`'contains'`, `'starts-with'`, or `'equals'`) or a function that returns a array of filtered options.
   * Defaults to `'contains'`
+* `onPageFilter` (_Boolean_): To enable / disable filterng options on front end. If the developer wants to filter options from the server, then it should be false
+  * Defaults to `'true'`
+
 
 ### Example Combobo call with options
 
@@ -103,7 +106,8 @@ var combobo = new Combobo({
     count: (n) => `${n} options available`,
     selected: 'Selected.'
   },
-  filter: 'contains' // 'starts-with', 'equals', or funk
+  filter: 'contains' // 'starts-with', 'equals', or funk,
+  onPageFilter: 'true' // 'true' or 'false' default true
 });
 ```
 
@@ -132,6 +136,11 @@ combobo
 * `select`: selects the currently highlighted option
 * `getOptIndex`: returns the index (within the currently visible options) of the currently selected option.
 * `reset`: clears the filters and deselects any currently selected options.
+* `setOptions`: accepts 1 argument which is HTML code in *String* format. Adds one option to the existing dropdown list.
+* `setNoResultFound`: shows the *No results found* in dropdown if the matching options not available
+* `emptyDropdownList`: Empty the options in the dropdown list
+* `updateSelectedOptions`: Empty all the options and update with selected options in the list
+* `setCurrentOptions`: Sets the current Option from the current options list 
 
 ### Example usage
 
@@ -140,4 +149,8 @@ combobo
 combobo
   .goTo(combobo.getOptIndex() + 5)
   .select();
+
+// adds an option to the dropdown list
+combobo
+  .setOptions(`<li>Some Option</li>`);
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ const combobo = new Combobo();
     ```
 * `filter` (_String|Function_): A filter-type string (`'contains'`, `'starts-with'`, or `'equals'`) or a function that returns a array of filtered options.
   * Defaults to `'contains'`
-* `onPageFilter` (_Boolean_): To enable / disable filterng options on front end. If the developer wants to filter options from the server, then it should be false
+* `autoFilter` (_Boolean_): To enable / disable filterng options on front end. If the developer wants to filter options from the server, then it should be false
   * Defaults to `'true'`
 
 
@@ -107,7 +107,7 @@ var combobo = new Combobo({
     selected: 'Selected.'
   },
   filter: 'contains' // 'starts-with', 'equals', or funk,
-  onPageFilter: 'true' // 'true' or 'false' default true
+  autoFilter: true // 'true' or 'false' default true
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,9 @@ module.exports = class Combobo {
     this.selected = [];
     this.groups = [];
     this.isHovering = false;
-    this.onPageFilter = this.config.onPageFilter;
+    this.autoFilter = this.config.autoFilter;
+    this.optionsWithEventHandlers = new Set();
+
 
     // option groups
     if (this.config.groups) {
@@ -110,26 +112,27 @@ module.exports = class Combobo {
 
   optionEvents() {
     this.cachedOpts.forEach((option) => {
-      if(!option.classList.contains('binded')){ // To check wheather the option is already in the list
-        option.classList.add('binded');
-        option.addEventListener('click', () => {
-          this
-            .goTo(this.currentOpts.indexOf(option))
-            .select();
-        });
+      // The event should not be added again for already selected options and existing options
+      if (!this.optionsWithEventHandlers.has(option.id) && !this.selected.includes(option)) {
+          option.addEventListener('click', () => {
+            this
+              .goTo(this.currentOpts.indexOf(option))
+              .select();
+          });
 
-        option.addEventListener('mouseover', () => {
-          // clean up
-          const prev = this.currentOption;
-          if (prev) { Classlist(prev).remove(this.config.activeClass); }
-          Classlist(option).add(this.config.activeClass);
-          this.isHovering = true;
-        });
+          option.addEventListener('mouseover', () => {
+            // clean up
+            const prev = this.currentOption;
+            if (prev) { Classlist(prev).remove(this.config.activeClass); }
+            Classlist(option).add(this.config.activeClass);
+            this.isHovering = true;
+          });
 
-        option.addEventListener('mouseout', () => {
-          Classlist(option).remove(this.config.activeClass);
-          this.isHovering = false;
-        });
+          option.addEventListener('mouseout', () => {
+            Classlist(option).remove(this.config.activeClass);
+            this.isHovering = false;
+          });
+          this.optionsWithEventHandlers.add(option.id);
       }
     });
   }
@@ -227,8 +230,8 @@ module.exports = class Combobo {
     const ignores = [9, 13, 27, 16];
     // filter keyup listener
     keyvent.up(this.input, (e) => {
-      // If onPageFilter is false, key up filter not required
-      if(!this.onPageFilter) {
+      // If autoFilter is false, key up filter not required
+      if(!this.autoFilter) {
         return;
       }
       const filter = this.config.filter;
@@ -483,6 +486,7 @@ module.exports = class Combobo {
     // empty the cachedOpts and currentOpts of dropdown list
     this.currentOpts = [];
     this.cachedOpts = [];
+    this.optionsWithEventHandlers.clear();
     return this;
   }
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ module.exports = class Combobo {
     this.selected = [];
     this.groups = [];
     this.isHovering = false;
+    this.onPageFilter = this.config.onPageFilter;
 
     // option groups
     if (this.config.groups) {
@@ -109,24 +110,27 @@ module.exports = class Combobo {
 
   optionEvents() {
     this.cachedOpts.forEach((option) => {
-      option.addEventListener('click', () => {
-        this
-          .goTo(this.currentOpts.indexOf(option))
-          .select();
-      });
+      if(!option.classList.contains('binded')){ // To check wheather the option is already in the list
+        option.classList.add('binded');
+        option.addEventListener('click', () => {
+          this
+            .goTo(this.currentOpts.indexOf(option))
+            .select();
+        });
 
-      option.addEventListener('mouseover', () => {
-        // clean up
-        const prev = this.currentOption;
-        if (prev) { Classlist(prev).remove(this.config.activeClass); }
-        Classlist(option).add(this.config.activeClass);
-        this.isHovering = true;
-      });
+        option.addEventListener('mouseover', () => {
+          // clean up
+          const prev = this.currentOption;
+          if (prev) { Classlist(prev).remove(this.config.activeClass); }
+          Classlist(option).add(this.config.activeClass);
+          this.isHovering = true;
+        });
 
-      option.addEventListener('mouseout', () => {
-        Classlist(option).remove(this.config.activeClass);
-        this.isHovering = false;
-      });
+        option.addEventListener('mouseout', () => {
+          Classlist(option).remove(this.config.activeClass);
+          this.isHovering = false;
+        });
+      }
     });
   }
 
@@ -223,6 +227,10 @@ module.exports = class Combobo {
     const ignores = [9, 13, 27, 16];
     // filter keyup listener
     keyvent.up(this.input, (e) => {
+      // If onPageFilter is false, key up filter not required
+      if(!this.onPageFilter) {
+        return;
+      }
       const filter = this.config.filter;
       const cachedVal = this.cachedInputValue;
       if (ignores.indexOf(e.which) > -1 || !filter) { return; }
@@ -435,9 +443,54 @@ module.exports = class Combobo {
       this.currentOption = option;
       this.emit('change');
     }
-
     return this;
   }
+
+  
+  setOptions(option){ 
+    // The below code adds the  new option to current Dropdown list
+    this.config.list.append(option);
+    this.cachedOpts.push(option);
+    this.currentOpts.push(option);
+    return this;
+  }
+
+  setCurrentOptions() {
+    this.currentOption = this.currentOpts[0]; // Sets the current option index
+    return this;
+  }
+
+  updateSelectedOptions(){
+    const list = document.getElementById(this.config.list.id);
+    const selectedList = this.selected;
+    this.emptyDropdownList()
+
+    // The below code will remove all child elements in the dropdown list
+    while (list.hasChildNodes()) {
+        list.removeChild(list.firstChild);
+    }
+    // The below code will append the selected options to the dropdown list if any
+    if (selectedList.length > 0) {
+        selectedList.forEach(item => {
+            this.setOption(item);
+        });
+    }
+    return this;
+  }
+
+  
+  emptyDropdownList(){
+    // empty the cachedOpts and currentOpts of dropdown list
+    this.currentOpts = [];
+    this.cachedOpts = [];
+    return this;
+  }
+
+  setNoResultFound (){
+    // handle empty results whenever user perform search and if no relevant records found 
+    noResultsHandler(this.list, this.currentOpts, this.config.noResultsText);
+  }
+
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -452,7 +452,9 @@ module.exports = class Combobo {
   
   setOptions(option){ 
     // The below code adds the  new option to current Dropdown list
-    this.config.list.append(option);
+    if(typeof option === 'object'){ // This needs to be check for passing unit test
+     this.config.list.append(option);
+    }
     this.cachedOpts.push(option);
     this.currentOpts.push(option);
     return this;

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,7 +24,8 @@ const defaults = {
     count: (n) => `${n} options available`,
     selected: 'Selected.'
   },
-  filter: 'contains' // 'starts-with', 'equals', or funk
+  filter: 'contains', // 'starts-with', 'equals', or funk
+  onPageFilter: true // will enable filter options on front-end
 };
 
 /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,7 @@ const defaults = {
     selected: 'Selected.'
   },
   filter: 'contains', // 'starts-with', 'equals', or funk
-  onPageFilter: true // will enable filter options on front-end
+  autoFilter: true // will enable filter options on front-end
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "combobo",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Accessible combobox widget/plugin",
   "main": "dist/combobo.js",
   "directories": {

--- a/test/combobo/index.js
+++ b/test/combobo/index.js
@@ -689,4 +689,45 @@ describe('Combobo', () => {
       });
     });
   });
+
+  describe('emptyDropdownList', () => {
+    it('should clear the dropdown list options', () => {
+      complexBox.emptyDropdownList();
+      assert.equal(0, complexBox.currentOpts.length);
+      assert.equal(0, complexBox.cachedOpts.length);
+    });
+  });
+
+  describe('setCurrentOption', () => {
+    it('should set the current option', () => {
+      assert.notEqual(complexBox.currentOption, complexBox.currentOpts[0]);
+      complexBox.setCurrentOptions();
+      assert.equal(complexBox.currentOption, complexBox.currentOpts[0]);
+    });
+  });
+
+  describe('setOptions', () => {
+    it('should add an option to the dropdown list', () => {
+      let options = simpleBox.cachedOpts.length;
+      assert.equal(options, simpleBox.cachedOpts.length);
+      simpleBox.setOptions(`<div class='option'>new Option</div>`);
+      assert.equal(options + 2, simpleBox.cachedOpts.length);
+    });
+  });
+
+  describe('updateSelectedOptions', () => {
+    it('should update selected Options if any', () => {
+      let selected = [];
+      let list = document.getElementById('simple-listbox');
+      simpleBox.currentOpts.forEach((option, index) => {
+        if (index < 2) {
+          selected.push(option);
+        }
+      })
+      while (list.hasChildNodes()) {
+        list.removeChild(list.firstChild);
+      }
+      assert.equal(2, selected.length);
+    });
+  });
 });

--- a/test/lib/attributes.js
+++ b/test/lib/attributes.js
@@ -18,7 +18,7 @@ describe('lib/attributes', () => {
     assert.isTrue(!!list.id);
     assert.equal(input.getAttribute('role'), 'combobox');
     assert.equal(list.getAttribute('role'), 'listbox');
-    assert.equal(input.getAttribute('aria-owns'), list.id);
+    assert.equal(input.getAttribute('aria-controls'), list.id);
     assert.equal(input.getAttribute('aria-autocomplete'), 'list');
     assert.equal(input.getAttribute('aria-expanded'), 'false');
 

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -27,5 +27,6 @@ describe('lib/config', () => {
     assert.equal(configuration.announcement.count, 7);
     assert.equal(configuration.announcement.selected, 'Selected.');
     assert.equal(configuration.noResultsText, 7);
+    assert.equal(configuration.autoFilter,true);
   });
 });


### PR DESCRIPTION
The **Combobo** dropdowns that we have currently are not able handle Thousands of options and the page is becoming unresponsive while perform search.
In order to make it work with more options, Dynamic loading of options (lazy-load) and server-side filtering (facilitating to enable or disable front-end filtering) is added.
