### PR TITLE
Multi Select - Allow spacebar key to select options of multi-select

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,6 @@ module.exports = class Combobo {
       });
 
       this.input.addEventListener('focus', () => {
-        
         this.input.select();
       });
 

--- a/index.js
+++ b/index.js
@@ -91,9 +91,7 @@ module.exports = class Combobo {
       });
 
       this.input.addEventListener('focus', () => {
-        if (this.selected.length) {
-          this.input.value = this.selected.length >= 2 ? '' : this.config.selectionValue(this.selected);
-        }
+        
         this.input.select();
       });
 
@@ -172,7 +170,7 @@ module.exports = class Combobo {
     if (focus) { this.input.focus(); }
     // Set the value back to what it was
     if (!this.multiselect && this.selected.length) {
-      this.input.value = this.config.selectionValue(this.selected);
+      this.input.value = this.selected.map(item => item.innerText).join(', ');
     }
 
     if (selectText) { this.input.select(); }
@@ -214,9 +212,20 @@ module.exports = class Combobo {
           e.preventDefault();
           e.stopPropagation();
           this.select();
+         
         }
       }
     }, {
+      keys: ['space'],
+      callback: (e) => {
+        if (this.isOpen) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.select();
+         
+        }
+      }
+    },{
       keys: ['escape'],
       callback: (e) => {
         if (this.isOpen) {
@@ -359,9 +368,7 @@ module.exports = class Combobo {
     }
 
     this.freshSelection = true;
-    this.input.value = this.selected.length
-      ? this.config.selectionValue(this.selected)
-      : '';
+    this.input.value = this.selected.length ? this.selected.map(item => item.innerText).join(', '): '';
     this.cachedInputValue = this.input.value;
     this.filter(true).clearFilters()
 


### PR DESCRIPTION
1. The Multi-select combobox has options that appear as a checkbox.  So a keyboard user would expect it to be operable by pressing **SpaceBar** Key.
2. If more than 1 options are selected , then display the selected values separated by comma.

A demo of these proposed  changes are available at this [code Pen.](https://codepen.io/Jaiprakash-Rai/full/MYWOrJP)